### PR TITLE
Temporarily disable code signing in build-and-publish workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -88,15 +88,15 @@ jobs:
         run: |
           rake "create_setup[${{env.APP_VERSION}}]"
 
-      - name: Sign Suite Setup with CodeSignTool
-        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
-        env:
-          ES_USERNAME: ${{ secrets.ES_USERNAME }}
-          ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
-          ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
-          ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
-        with:
-          file_path: ./output/OSPSuite-Full.${{env.APP_VERSION}}.exe
+#      - name: Sign Suite Setup with CodeSignTool
+#        uses: Open-Systems-Pharmacology/Workflows/.github/actions/codesigner-SSL@main
+#        env:
+#          ES_USERNAME: ${{ secrets.ES_USERNAME }}
+#          ES_PASSWORD: ${{ secrets.ES_PASSWORD }}
+#          ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
+#          ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
+#        with:
+#          file_path: ./output/OSPSuite-Full.${{env.APP_VERSION}}.exe
 
       - name: Push full as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
S. https://github.com/Open-Systems-Pharmacology/Suite/issues/181 
If the setup runs again after this, then the problem is indeed the code signing.

If so, I will try to switch the [signing method from v1 to v2](https://github.com/SSLcom/esigner-codesign) (which is absolutely not documented by them, so trial and error).